### PR TITLE
Add work around for Emacs #18845 bug

### DIFF
--- a/chapel-mode.el
+++ b/chapel-mode.el
@@ -41,6 +41,11 @@
 
 ;;; Code:
 
+;; Work around emacs bug#18845, cc-mode expects cl to be loaded
+(eval-and-compile
+  (when (and (= emacs-major-version 24) (>= emacs-minor-version 4))
+    (require 'cl)))
+
 (require 'cc-mode)
 
 ;; These are only required at compile time to get the sources for the


### PR DESCRIPTION
Emacs 24.4 and 24.5 have cc-mode bug. So they cannot load chapel-mode. This change applies work around of its bug. Development Emacs(version 25) already fixed this bug.

See also
- https://debbugs.gnu.org/cgi/bugreport.cgi?bug=18845