### PR TITLE
Support nested block comments

### DIFF
--- a/chapel-mode.el
+++ b/chapel-mode.el
@@ -46,6 +46,9 @@
   (when (and (= emacs-major-version 24) (>= emacs-minor-version 4))
     (require 'cl)))
 
+;; Need to exclude xemacs from some behavior
+(defvar running-xemacs (string-match "XEmacs\\|Lucid" emacs-version))
+
 (require 'cc-mode)
 
 ;; These are only required at compile time to get the sources for the
@@ -346,6 +349,12 @@ need for `chapel-font-lock-extra-types'.")
 (or chapel-mode-syntax-table
     (setq chapel-mode-syntax-table
 	  (funcall (c-lang-const c-make-mode-syntax-table chapel))))
+
+;; Nested block comments -- add "n" to the syntax table entry for "*"
+;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-Flags.html#Syntax-Flags
+(if (not running-xemacs) ; xemacs doesn't support the "n" modifier.
+    (modify-syntax-entry ?* ". 23n" chapel-mode-syntax-table))
+
 
 (defvar chapel-mode-abbrev-table nil
   "Abbreviation table used in chapel-mode buffers.")


### PR DESCRIPTION
C-h s gives this translation of the effects of (modify-syntax-entry ?* ". 23n") on the syntax-table entry for *
```
*		. 23n	which means: punctuation,
	  is the second character of a comment-start sequence,
	  is the first character of a comment-end sequence (nestable)

```
xemacs doesn't support this syntax-table syntax.

Tested on emacs 24.5.1.
Tested that this doesn't break chapel-mode on xemacs 21.4.
